### PR TITLE
Require peer dependency in `npm install` in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ You can view usage of ```jsoneditor-react``` using our storybook.
 #### Steps to run storybook
 
 * fork or clone repository
-* ```npm install```
+* ```npm install jsoneditor```
 * ```npm run dev```
 * View ```http://localhost:9001```
 


### PR DESCRIPTION
Storybook doesn't run without `jsoneditor` being installed.