### PR TITLE
Add property sortObjectKeys to Editor

### DIFF
--- a/src/Editor.jsx
+++ b/src/Editor.jsx
@@ -67,6 +67,8 @@ modes.allValues = values;
  * @property {(string|PropTypes.elementType)} [tag='div'] - Html element, or react element to render
  * @property {object} [htmlElementProps] - html element custom props
  * @property {Function} [innerRef] - callback to get html element reference
+ * @property {boolean} [sortObjectKeys=false] If true, object keys in 'tree', 'view' or 'form' mode list 
+ * be listed alphabetically instead by their insertion order..
  */
 export default class Editor extends Component {
     constructor(props) {
@@ -222,6 +224,7 @@ Editor.propTypes = {
     name: PropTypes.string,
     schema: PropTypes.object,
     schemaRefs: PropTypes.object,
+    sortObjectKeys: PropTypes.bool,
 
     onChange: PropTypes.func,
     onError: PropTypes.func,
@@ -249,6 +252,7 @@ Editor.defaultProps = {
     search: true,
     navigationBar: true,
     statusBar: true,
+    sortObjectKeys: false,
 };
 
 /**


### PR DESCRIPTION
Add the property sortObjectKeys, which allows sorting the entries by default. 

{boolean} sortObjectKeys - If true, object keys in 'tree', 'view' or 'form' mode list be listed alphabetically instead by their insertion order. Sorting is performed using a natural sort algorithm, which makes it easier to see objects that have string numbers as keys. false by default.

As described in:
https://github.com/josdejong/jsoneditor/blob/master/docs/api.md