### PR TITLE
Reset this.err and call onError with error change

### DIFF
--- a/src/Editor.jsx
+++ b/src/Editor.jsx
@@ -178,7 +178,8 @@ export default class Editor extends Component {
                     this.props.onChange(currentJson);
                 }
             } catch (err) {
-                this.err = err;
+                const currentJson = this.jsonEditor.get();
+                this.props.onChange(currentJson);
             }
         }
     }

--- a/src/Editor.jsx
+++ b/src/Editor.jsx
@@ -168,6 +168,7 @@ export default class Editor extends Component {
     handleChange() {
         if (this.props.onChange) {
             try {
+                this.err = null;
                 const text = this.jsonEditor.getText();
                 if (text === '') {
                     this.props.onChange(null);
@@ -178,8 +179,11 @@ export default class Editor extends Component {
                     this.props.onChange(currentJson);
                 }
             } catch (err) {
-                const currentJson = this.jsonEditor.get();
-                this.props.onChange(currentJson);
+                this.err = err;
+				if(this.props.onError) {
+                  const error = typeof err === 'object' ? err.message : err;
+                  this.props.onError(error);
+                }
             }
         }
     }


### PR DESCRIPTION
This resolves two issues

When you change the value in the JSON editor only this.err is updated but is unreliable due to it not being cleared. So a call to onError would help
https://github.com/vankop/jsoneditor-react/issues/17

Reset this.err when there is no longer an error with the json to make it more reliable
https://github.com/vankop/jsoneditor-react/issues/30