### PR TITLE
Update install instructions with required version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ react wrapper implementation for [josdejong/jsoneditor](https://github.com/josde
 ## Installation
 
 ```
-npm install --save jsoneditor jsoneditor-react
+npm install --save jsoneditor@^7.1.0 jsoneditor-react
 ```
 
 ```jsoneditor-react``` using minimalist version of ```jsoneditor``` to minimize flat bundle size, so if you want to use [Ajv](https://github.com/epoberezkin/ajv) or [Ace Editor](https://github.com/thlorenz/brace) install them as well


### PR DESCRIPTION
jsoneditor is on version 9.#.#, but jsoneditor-react requires ^7.0.1. Update the install instructions to tell you to install the required version of jsoneditor instead of the latest.

Alternatively, could check if you can update to the latest jsoneditor.

Also, as of npm 5.0.0, you no longer need `--save` to save dependencies, but maybe worth keeping in the README in case folks are still on older versions? 