### PR TITLE
String, booleans and number are JSON too

### DIFF
--- a/src/Editor.jsx
+++ b/src/Editor.jsx
@@ -219,7 +219,13 @@ export default class Editor extends Component {
 
 Editor.propTypes = {
     //  jsoneditor props
-    value: PropTypes.oneOfType([PropTypes.object, PropTypes.array, PropTypes.string, PropTypes.bool, PropTypes.number]),
+    value: PropTypes.oneOfType([
+        PropTypes.object,
+        PropTypes.array,
+        PropTypes.string,
+        PropTypes.bool,
+        PropTypes.number,
+    ]),
     mode: PropTypes.oneOf(values),
     name: PropTypes.string,
     schema: PropTypes.object,

--- a/src/Editor.jsx
+++ b/src/Editor.jsx
@@ -219,7 +219,7 @@ export default class Editor extends Component {
 
 Editor.propTypes = {
     //  jsoneditor props
-    value: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+    value: PropTypes.oneOfType([PropTypes.object, PropTypes.array, PropTypes.string, PropTypes.bool, PropTypes.number]),
     mode: PropTypes.oneOf(values),
     name: PropTypes.string,
     schema: PropTypes.object,


### PR DESCRIPTION
Hello, first of all, thank you for your work!

[Strings, booleans, and numbers are legal values for JSON](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON#full_json_syntax), and `jsoneditor` permits them too. This is just a `propTypes` fix.
